### PR TITLE
Login with Google

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,5 @@
 PORT=3000
 OPENCAGEDATA_API_KEY=your key here
+OAUTH2_GOOGLE_API_KEY=your key here
+OAUTH2_GOOGLE_API_SECRET=your secret here
+OAUTH2_GOOGLE_REDIRECT_URI=redirect uri

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,4 +7,10 @@ module.exports = {
       },
     },
   },
+  rules: {
+    '@typescript-eslint/camelcase': 'off',
+    'new-cap': 'off',
+    'import/no-unresolved': 'off', // False negatives
+    'import/named': 'off', // False negatives
+  },
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,15 @@
     "lint": "eslint --ext .ts ."
   },
   "dependencies": {
+    "@hapi/joi": "^15.0.2",
     "apollo-server-koa": "2.4.8",
     "awilix": "4.2.2",
+    "awilix-koa": "^3.1.0",
     "axios": "^0.18.0",
     "dotenv": "7.0.0",
     "graphql": "14.2.1",
     "koa": "2.7.0",
+    "koa-route": "^3.2.0",
     "lodash.merge": "4.6.1",
     "node-uuid": "1.4.8"
   },
@@ -30,8 +33,10 @@
     "@types/dotenv": "6.1.1",
     "@types/glob": "^7.1.1",
     "@types/graphql": "14.2.0",
+    "@types/hapi__joi": "^15.0.1",
     "@types/jest": "24.0.12",
     "@types/koa": "2.0.48",
+    "@types/koa-route": "^3.2.4",
     "@types/lodash.merge": "4.6.6",
     "@types/node-uuid": "0.0.28",
     "@typescript-eslint/eslint-plugin": "1.7.0",

--- a/src/application/repository/User.ts
+++ b/src/application/repository/User.ts
@@ -1,0 +1,6 @@
+import { User } from '../../domain/model'
+
+export interface UserRepository {
+  persist: (spot: User) => Promise<User>
+  findByEmail: (email: string) => Promise<User | null>
+}

--- a/src/application/repository/index.ts
+++ b/src/application/repository/index.ts
@@ -1,1 +1,2 @@
 export * from './Spot'
+export * from './User'

--- a/src/domain/model/User.ts
+++ b/src/domain/model/User.ts
@@ -1,0 +1,7 @@
+export class User {
+  public constructor(
+    public id: string,
+    public googleId: string,
+    public email: string
+  ) {}
+}

--- a/src/domain/model/index.ts
+++ b/src/domain/model/index.ts
@@ -1,2 +1,3 @@
 export * from './Spot'
 export * from './Location'
+export * from './User'

--- a/src/domain/usecase/index.ts
+++ b/src/domain/usecase/index.ts
@@ -1,3 +1,4 @@
 export * from './create-spot'
 export * from './search-spots'
 export * from './get-spot'
+export * from './link-social-account'

--- a/src/domain/usecase/link-social-account.test.ts
+++ b/src/domain/usecase/link-social-account.test.ts
@@ -1,0 +1,53 @@
+import { UserRepository } from '../..//application/repository'
+import { UserInMemory } from '../../infrastructure/repository/UserInMemory'
+import { User } from '../model'
+
+import { linkSocialAccount, LinkSocialAccount } from './link-social-account'
+
+let usecase: LinkSocialAccount
+let userRepository: UserRepository
+
+beforeEach(() => {
+  userRepository = UserInMemory()
+  usecase = linkSocialAccount({ userRepository })
+})
+
+it('should do nothing when the user already exists', async () => {
+  // Given
+  const user = new User('user-id', 'google-id', 'john.doe@example.com')
+  await userRepository.persist(user)
+  const spy = jest.spyOn(userRepository, 'persist')
+
+  // When
+  const result = await usecase({
+    email: 'john.doe@example.com',
+    googleId: 'google-id',
+  })
+
+  // Then
+  expect(result).toEqual(user)
+  expect(spy).not.toHaveBeenCalled()
+})
+
+it('should create the user when it does not exist', async () => {
+  // Given
+  const email = 'john.doe@example.com'
+  const googleId = 'google-id'
+  const spy = jest.spyOn(userRepository, 'persist')
+
+  // When
+  const result = await usecase({ email, googleId })
+
+  // Then
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(spy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      email: 'john.doe@example.com',
+      googleId: 'google-id',
+      id: expect.any(String),
+    })
+  )
+  expect(result.email).toEqual('john.doe@example.com')
+  expect(result.googleId).toEqual('google-id')
+  expect(result.id).toEqual(expect.any(String))
+})

--- a/src/domain/usecase/link-social-account.ts
+++ b/src/domain/usecase/link-social-account.ts
@@ -1,0 +1,29 @@
+import * as uuid from 'node-uuid'
+
+import { UserRepository } from '../../application/repository'
+import { User } from '../model'
+
+interface Dependencies {
+  userRepository: UserRepository
+}
+
+export type LinkSocialAccount = (options: {
+  email: string
+  googleId: string
+}) => Promise<User>
+
+export const linkSocialAccount = ({
+  userRepository,
+}: Dependencies): LinkSocialAccount => async ({ email, googleId }) => {
+  const existingUser = await userRepository.findByEmail(email)
+
+  if (existingUser) {
+    return existingUser
+  }
+
+  const user = new User(uuid.v4(), googleId, email)
+
+  await userRepository.persist(user)
+
+  return user
+}

--- a/src/infrastructure/repository/UserInMemory.ts
+++ b/src/infrastructure/repository/UserInMemory.ts
@@ -1,0 +1,22 @@
+import { UserRepository } from '../../application/repository'
+import { User } from '../../domain/model'
+
+interface Database {
+  [key: string]: User
+}
+
+export const UserInMemory = (): UserRepository => {
+  const database: Database = {}
+
+  return {
+    persist: user => {
+      database[user.id] = user
+
+      return Promise.resolve(user)
+    },
+    findByEmail: email =>
+      Promise.resolve(
+        Object.values(database).find(user => user.email === email) || null
+      ),
+  }
+}

--- a/src/infrastructure/server/graphql/index.ts
+++ b/src/infrastructure/server/graphql/index.ts
@@ -1,10 +1,13 @@
-import { gql, makeExecutableSchema } from 'apollo-server-koa'
-import merge from 'lodash.merge' // eslint-disable-line
+import { ApolloServer, gql, makeExecutableSchema } from 'apollo-server-koa'
+import merge from 'lodash.merge'
+import Koa from 'koa'
 
 import { SpotSchema } from './spot/schema'
 import { LocationSchema } from './location/schema'
 import { SpotResolvers } from './spot/resolver'
 import { LocationResolvers } from './location/resolver'
+import { GraphlQlContext } from './types'
+import { getContainerFromKoaContext } from '../util'
 
 const Query = gql`
   type Query {
@@ -15,8 +18,34 @@ const Query = gql`
   }
 `
 
-export const schema = makeExecutableSchema({
+const schema = makeExecutableSchema({
   typeDefs: [Query, SpotSchema, LocationSchema],
   // @ts-ignore
   resolvers: merge(SpotResolvers, LocationResolvers),
 })
+
+export const configureGraphql = (app: Koa): Koa => {
+  const server = new ApolloServer({
+    schema,
+    context: ({ ctx: koaContext }): GraphlQlContext => {
+      const container = getContainerFromKoaContext(koaContext)
+
+      return {
+        currentUser: container.resolve('currentUser'),
+        usecases: {
+          createSpot: container.resolve('createSpot'),
+          searchSpots: container.resolve('searchSpots'),
+          getSpot: container.resolve('getSpot'),
+          linkSocialAccount: container.resolve('linkSocialAccount'),
+        },
+        services: {
+          geolocation: container.resolve('geolocationService'),
+        },
+      }
+    },
+  })
+
+  server.applyMiddleware({ app })
+
+  return app
+}

--- a/src/infrastructure/server/graphql/location/resolver.ts
+++ b/src/infrastructure/server/graphql/location/resolver.ts
@@ -1,21 +1,17 @@
 import { Location } from '../../../../domain/model'
 import { GraphlQlContext } from '../types'
 
-interface LocationResolver {
+const LocationResolver = {
   address: (
-    parent: Location,
+    location: Location,
     _args: null,
     context: GraphlQlContext
-  ) => Promise<String | null>
-}
-
-const Location: LocationResolver = {
-  address: (location, _args, context) =>
+  ): Promise<string | null> =>
     context.services.geolocation.getAddressForLocation(location),
 }
 
 export const LocationResolvers = {
   Query: {},
   Mutation: {},
-  Location,
+  Location: LocationResolver,
 }

--- a/src/infrastructure/server/graphql/types.ts
+++ b/src/infrastructure/server/graphql/types.ts
@@ -1,13 +1,21 @@
-import { CreateSpot, SearchSpots, GetSpot } from '../../../domain/usecase'
-import { GeolocationService } from '../../services/geolocation'
+import {
+  CreateSpot,
+  SearchSpots,
+  GetSpot,
+  LinkSocialAccount,
+} from '../../../domain/usecase'
+import { User } from '../../../domain/model'
+import { GeolocationService } from '../../services/Geolocation'
 
 export interface GraphlQlContext {
   usecases: {
     createSpot: CreateSpot
     searchSpots: SearchSpots
     getSpot: GetSpot
+    linkSocialAccount: LinkSocialAccount
   }
   services: {
     geolocation: GeolocationService
   }
+  currentUser: User | null
 }

--- a/src/infrastructure/server/middlewares/authorize.ts
+++ b/src/infrastructure/server/middlewares/authorize.ts
@@ -1,0 +1,55 @@
+import Koa from 'koa'
+import { asValue } from 'awilix'
+import { makeInvoker } from 'awilix-koa'
+
+import { UserRepository } from '../../../application/repository'
+import { User } from '../../../domain/model'
+import { GoogleAuthService } from '../../services/GoogleAuthService'
+import { getContainerFromKoaContext } from '../util'
+
+interface Dependencies {
+  userRepository: UserRepository
+  googleAuthService: GoogleAuthService
+}
+
+const getAccessTokenFromHeaders = (
+  request: Koa.Request
+): string | undefined => {
+  const authorizationHeader: string = request.headers.authorization || ''
+  const [, accessToken] = authorizationHeader.split(' ')
+
+  return accessToken
+}
+
+class AuthorizationMiddleware {
+  private userRepository: UserRepository
+  private googleAuthService: GoogleAuthService
+
+  public constructor({ userRepository, googleAuthService }: Dependencies) {
+    this.userRepository = userRepository
+    this.googleAuthService = googleAuthService
+  }
+
+  public authorize: Koa.Middleware = async (ctx, next) => {
+    const accessToken = getAccessTokenFromHeaders(ctx.request)
+    const container = getContainerFromKoaContext(ctx)
+
+    let currentUser: User | null = null
+
+    if (accessToken) {
+      const googleUser = await this.googleAuthService.getCurrentUser(
+        accessToken
+      )
+      currentUser = await this.userRepository.findByEmail(googleUser.email)
+    }
+
+    container.register({
+      currentUser: asValue(currentUser),
+    })
+    return next()
+  }
+}
+
+export const authorizationMiddleware = makeInvoker(AuthorizationMiddleware)(
+  'authorize'
+)

--- a/src/infrastructure/server/middlewares/index.ts
+++ b/src/infrastructure/server/middlewares/index.ts
@@ -1,0 +1,14 @@
+import Koa from 'koa'
+import { AwilixContainer } from 'awilix'
+import { scopePerRequest } from 'awilix-koa'
+
+import { authorizationMiddleware } from './authorize'
+
+export const configureMiddlewares = (
+  app: Koa,
+  container: AwilixContainer
+): Koa => {
+  app.use(scopePerRequest(container)).use(authorizationMiddleware)
+
+  return app
+}

--- a/src/infrastructure/server/routes/index.ts
+++ b/src/infrastructure/server/routes/index.ts
@@ -1,0 +1,9 @@
+import Koa from 'koa'
+
+import * as oauth2 from './oauth2'
+
+export const configureRoutes = (app: Koa): Koa => {
+  oauth2.configureGoogleRoutes(app)
+
+  return app
+}

--- a/src/infrastructure/server/routes/oauth2/google.ts
+++ b/src/infrastructure/server/routes/oauth2/google.ts
@@ -1,0 +1,93 @@
+import qs from 'querystring'
+import Koa from 'koa'
+import router from 'koa-route'
+import Joi from '@hapi/joi'
+
+import { LinkSocialAccount } from '../../../../domain/usecase'
+import { GoogleAuthService } from '../../../services/GoogleAuthService'
+import { validateSchemaOrThrow } from '../../util'
+import { makeInvoker } from 'awilix-koa'
+
+interface AuthorizeQuery {
+  redirect: string
+}
+
+interface Oauth2Query {
+  code: string
+  state: string
+}
+
+interface Dependencies {
+  googleAuthService: GoogleAuthService
+  linkSocialAccount: LinkSocialAccount
+}
+
+class GoogleOauth2Api {
+  private googleAuthService: GoogleAuthService
+  private linkSocialAccount: LinkSocialAccount
+
+  public constructor({ googleAuthService, linkSocialAccount }: Dependencies) {
+    this.googleAuthService = googleAuthService
+    this.linkSocialAccount = linkSocialAccount
+  }
+
+  public redirectToLogin: Koa.Middleware = ctx => {
+    const query: AuthorizeQuery = ctx.request.query
+    validateSchemaOrThrow(
+      Joi.object()
+        .keys({
+          redirect: Joi.string().required(),
+        })
+        .required(),
+      query
+    )
+
+    ctx.redirect(this.googleAuthService.getAuthorizeUrl(query.redirect))
+  }
+
+  public handleOauth2Callback: Koa.Middleware = async ctx => {
+    const query: Oauth2Query = ctx.request.query
+    validateSchemaOrThrow(
+      Joi.object()
+        .keys({
+          code: Joi.string().required(),
+          state: Joi.string().required(),
+        })
+        .unknown(true)
+        .required(),
+      query
+    )
+
+    const code = query.code
+    const redirectUri = query.state
+
+    const {
+      accessToken,
+      refreshToken,
+    } = await this.googleAuthService.getCredentials(code)
+
+    const user = await this.googleAuthService.getCurrentUser(accessToken)
+
+    await this.linkSocialAccount({
+      email: user.email,
+      googleId: user.sub,
+    })
+
+    ctx.redirect(
+      `${redirectUri}?${qs.stringify({
+        accessToken,
+        refreshToken,
+      })}`
+    )
+  }
+}
+
+const handler = makeInvoker(GoogleOauth2Api)
+
+export const configureGoogleRoutes = (app: Koa): Koa => {
+  app
+    .use(router.get('/authorize/google', handler('redirectToLogin')))
+    .use(router.get('/oauth2/google', handler('handleOauth2Callback')))
+
+  return app
+}

--- a/src/infrastructure/server/routes/oauth2/index.ts
+++ b/src/infrastructure/server/routes/oauth2/index.ts
@@ -1,0 +1,1 @@
+export * from './google'

--- a/src/infrastructure/server/util/index.test.ts
+++ b/src/infrastructure/server/util/index.test.ts
@@ -1,0 +1,37 @@
+import Joi from '@hapi/joi'
+
+import { validateSchemaOrThrow } from '.'
+
+describe('validateSchemaOrThrow', () => {
+  it('should not throw when the object matches the schema', () => {
+    expect.assertions(1)
+
+    // Given
+    const schema = Joi.object({
+      id: Joi.string().required(),
+    }).required()
+
+    const object = {
+      id: 'some-id',
+    }
+
+    // Then
+    expect(() => validateSchemaOrThrow(schema, object)).not.toThrow()
+  })
+
+  it('should throw an error when the object does not match the schema', () => {
+    expect.assertions(1)
+
+    // Given
+    const schema = Joi.object({
+      id: Joi.string().required(),
+    }).required()
+
+    const object = {
+      iddd: 'some-id',
+    }
+
+    // Then
+    expect(() => validateSchemaOrThrow(schema, object)).toThrow()
+  })
+})

--- a/src/infrastructure/server/util/index.ts
+++ b/src/infrastructure/server/util/index.ts
@@ -1,0 +1,26 @@
+import { AwilixContainer } from 'awilix'
+import Koa from 'koa'
+import Joi from '@hapi/joi'
+
+export const getContainerFromKoaContext = (
+  ctx: Koa.ParameterizedContext
+): AwilixContainer => {
+  const container = ctx.state.container
+
+  if (!container) {
+    throw new Error('DI container was not found in context.')
+  }
+
+  return container
+}
+
+export const validateSchemaOrThrow = (
+  schema: Joi.ObjectSchema,
+  value: any
+): void => {
+  const error = schema.validate(value).error
+
+  if (error) {
+    throw error
+  }
+}

--- a/src/infrastructure/services/Geolocation.test.ts
+++ b/src/infrastructure/services/Geolocation.test.ts
@@ -1,0 +1,80 @@
+import axios from 'axios'
+
+import { castToJestMock } from '../../test-utils'
+import { GeolocationService } from './Geolocation'
+
+jest.mock('axios')
+
+let clientId: string
+let service: GeolocationService
+
+beforeEach(() => {
+  clientId = 'client-id'
+  service = new GeolocationService({ openCageDataApiKey: clientId })
+})
+
+describe('getAddressForLocation', () => {
+  it('should call the correct URL', async () => {
+    // Given
+    castToJestMock(axios.get).mockResolvedValue({
+      data: {
+        results: [],
+      },
+    })
+
+    // When
+    await service.getAddressForLocation({
+      latitude: 19.2,
+      longitude: 55.9,
+    })
+
+    // Then
+    expect(axios.get).toHaveBeenCalledTimes(1)
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.opencagedata.com/geocode/v1/json?q=19.2+55.9&key=client-id'
+    )
+  })
+
+  it('should return the formatted address if existing', async () => {
+    // Given
+    castToJestMock(axios.get).mockResolvedValue({
+      data: {
+        results: [
+          {
+            formatted: '34 Avenue des Champs Elysées',
+          },
+          {
+            formatted: '1 Avenue Henry Martin',
+          },
+        ],
+      },
+    })
+
+    // When
+    const result = await service.getAddressForLocation({
+      latitude: 19.2,
+      longitude: 55.9,
+    })
+
+    // Then
+    expect(result).toEqual('34 Avenue des Champs Elysées')
+  })
+
+  it('should return null if it does not exist', async () => {
+    // Given
+    castToJestMock(axios.get).mockResolvedValue({
+      data: {
+        results: [],
+      },
+    })
+
+    // When
+    const result = await service.getAddressForLocation({
+      latitude: 19.2,
+      longitude: 55.9,
+    })
+
+    // Then
+    expect(result).toEqual(null)
+  })
+})

--- a/src/infrastructure/services/Geolocation.ts
+++ b/src/infrastructure/services/Geolocation.ts
@@ -7,25 +7,27 @@ interface Dependencies {
   openCageDataApiKey: string
 }
 
-export interface GeolocationService {
-  getAddressForLocation: (location: Location) => Promise<string | null>
+interface OpenCageDataResponse {
+  results: Array<{
+    formatted: string
+  }>
 }
 
-export const createGeolocationService = ({
-  openCageDataApiKey,
-}: Dependencies): GeolocationService => ({
-  getAddressForLocation: location => {
+export class GeolocationService {
+  private clientId: string
+
+  public constructor({ openCageDataApiKey }: Dependencies) {
+    this.clientId = openCageDataApiKey
+  }
+
+  public getAddressForLocation(location: Location): Promise<string | null> {
     const params = {
       q: `${location.latitude}+${location.longitude}`,
-      key: openCageDataApiKey,
+      key: this.clientId,
     }
 
     return axios
-      .get<{
-        results: Array<{
-          formatted: string
-        }>
-      }>(
+      .get<OpenCageDataResponse>(
         `https://api.opencagedata.com/geocode/v1/json?${qs.stringify(
           params,
           undefined,
@@ -43,5 +45,5 @@ export const createGeolocationService = ({
 
         return data.results[0].formatted
       })
-  },
-})
+  }
+}

--- a/src/infrastructure/services/GoogleAuthService.test.ts
+++ b/src/infrastructure/services/GoogleAuthService.test.ts
@@ -1,0 +1,107 @@
+import axios from 'axios'
+
+import { castToJestMock } from '../../test-utils'
+import { GoogleAuthService } from './GoogleAuthService'
+
+jest.mock('axios')
+
+let service: GoogleAuthService
+
+beforeEach(() => {
+  service = new GoogleAuthService({
+    googleClientId: 'client-id',
+    googleClientSecret: 'client-secret',
+    googleRedirectUri: 'redirect-uri',
+  })
+})
+
+describe('getAuthorizeUrl', () => {
+  it('should return the correct URL', () => {
+    // Given
+    const successRedirectUri = 'http://example.com'
+
+    // When
+    const authorizeUrl = service.getAuthorizeUrl(successRedirectUri)
+
+    // Then
+    expect(authorizeUrl).toEqual(
+      'https://accounts.google.com/o/oauth2/v2/auth?client_id=client-id&redirect_uri=redirect-uri&state=http%3A%2F%2Fexample.com&include_granted_scopes=true&access_type=offline&response_type=code&scope=profile%20email'
+    )
+  })
+})
+
+describe('getCredentials', () => {
+  beforeEach(() => {
+    castToJestMock(axios.post).mockResolvedValue({
+      data: {
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+      },
+    })
+  })
+
+  it('should call the correct URL', async () => {
+    // Given
+    const authorizationCode = 'authorization-code'
+
+    // When
+    await service.getCredentials(authorizationCode)
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://www.googleapis.com/oauth2/v4/token',
+      {
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+        code: 'authorization-code',
+        grant_type: 'authorization_code',
+        redirect_uri: 'redirect-uri',
+      }
+    )
+  })
+
+  it('should return the credentials', async () => {
+    // Given
+    const authorizationCode = 'authorization-code'
+
+    // When
+    const result = await service.getCredentials(authorizationCode)
+
+    expect(result).toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    })
+  })
+})
+
+describe('getCurrentUser', () => {
+  beforeEach(() => {
+    castToJestMock(axios.get).mockResolvedValue({
+      data: 'user-info',
+    })
+  })
+
+  it('should call the correct URL', async () => {
+    // Given
+    const accessToken = 'access-token'
+
+    // When
+    await service.getCurrentUser(accessToken)
+
+    expect(axios.get).toHaveBeenCalledTimes(1)
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://www.googleapis.com/oauth2/v3/userinfo',
+      { headers: { Authorization: 'Bearer access-token' } }
+    )
+  })
+
+  it('should return the user', async () => {
+    // Given
+    const accessToken = 'access-token'
+
+    // When
+    const result = await service.getCurrentUser(accessToken)
+
+    expect(result).toEqual('user-info')
+  })
+})

--- a/src/infrastructure/services/GoogleAuthService.ts
+++ b/src/infrastructure/services/GoogleAuthService.ts
@@ -1,0 +1,84 @@
+import qs from 'querystring'
+import axios from 'axios'
+
+interface Dependencies {
+  googleClientId: string
+  googleClientSecret: string
+  googleRedirectUri: string
+}
+
+interface GoogleTokenResponse {
+  access_token: string
+  refresh_token: string
+}
+
+interface GoogleUserResponse {
+  sub: string
+  email: string
+  given_name: string
+  family_name: string
+  picture?: string
+}
+
+export interface Credentials {
+  accessToken: string
+  refreshToken: string
+}
+
+const OAUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
+const API_V3_ENDPOINT = 'https://www.googleapis.com/oauth2/v3'
+const API_V4_ENDPOINT = 'https://www.googleapis.com/oauth2/v4'
+
+export class GoogleAuthService {
+  private clientId: string
+  private clientSecret: string
+  private redirectUri: string
+
+  public constructor({
+    googleClientId,
+    googleClientSecret,
+    googleRedirectUri,
+  }: Dependencies) {
+    this.clientId = googleClientId
+    this.clientSecret = googleClientSecret
+    this.redirectUri = googleRedirectUri
+  }
+
+  public getAuthorizeUrl(successRedirectUri: string): string {
+    return `${OAUTH_ENDPOINT}?${qs.stringify({
+      client_id: this.clientId,
+      redirect_uri: this.redirectUri,
+      state: successRedirectUri,
+      include_granted_scopes: true,
+      access_type: 'offline',
+      response_type: 'code',
+      scope: 'profile email',
+    })}`
+  }
+
+  public getCredentials(authorizationCode: string): Promise<Credentials> {
+    return axios
+      .post<GoogleTokenResponse>(`${API_V4_ENDPOINT}/token`, {
+        code: authorizationCode,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        redirect_uri: this.redirectUri,
+        grant_type: 'authorization_code',
+      })
+      .then(response => response.data)
+      .then(data => ({
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+      }))
+  }
+
+  public getCurrentUser(accessToken: string): Promise<GoogleUserResponse> {
+    return axios
+      .get<GoogleUserResponse>(`${API_V3_ENDPOINT}/userinfo`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .then(response => response.data)
+  }
+}

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,0 +1,1 @@
+export const castToJestMock = (obj: any): jest.Mock => obj

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,6 +151,32 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@hapi/address@2.x.x":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
+  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
+
+"@hapi/hoek@6.x.x":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-6.2.1.tgz#d3a66329159af879bfdf0b0cff2229c43c5a3451"
+  integrity sha512-+ryw4GU9pjr1uT6lBuErHJg3NYqzwJTvZ75nKuJijEzpd00Uqi6oiawTGDDf5Hl0zWmI7qHfOtaqB0kpQZJQzA==
+
+"@hapi/joi@^15.0.2":
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.0.2.tgz#2989041a06ee2941cf6dd247ffff8032640d16bb"
+  integrity sha512-c3NwWBHzUnEavcaCpGaepOcygS17pSnOh5ZYUBz+sfqCP7kC9haLcRnd3U8KFC4TbLFmRwKnmYglsc47m9yapg==
+  dependencies:
+    "@hapi/address" "2.x.x"
+    "@hapi/hoek" "6.x.x"
+    "@hapi/topo" "3.x.x"
+
+"@hapi/topo@3.x.x":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.0.tgz#5c47cd9637c2953db185aa957a27bcb2a8b7a6f8"
+  integrity sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==
+  dependencies:
+    "@hapi/hoek" "6.x.x"
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -477,6 +503,13 @@
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.2.0.tgz#74e1da5f2a4a744ac6eb3ed57b48242ea9367202"
   integrity sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw==
 
+"@types/hapi__joi@*", "@types/hapi__joi@^15.0.1":
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.1.tgz#6038375074af792b765e34dc799c83d30a406fbe"
+  integrity sha512-uqH3kTO1nrhe+Pbq+dQKrulrfscRPjFZNv9UWA3FupJZBHw+miT7yiV6C8A80YLnn0o6zbgTProncBb3d7QohA==
+  dependencies:
+    "@types/hapi__joi" "*"
+
 "@types/http-assert@*":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.4.0.tgz#41d173466e396e99a14d75f7160cc997f2f9ed8b"
@@ -517,6 +550,14 @@
   integrity sha512-kXvR0DPyZ3gaFxZs4WycA8lpzlPGtFmwdbgce+NWd+TG3PycPO3o5FkePH60HoBPd8BBaSiw3vhtgM42O2kQcg==
   dependencies:
     "@types/koa" "*"
+
+"@types/koa-route@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@types/koa-route/-/koa-route-3.2.4.tgz#65fe3308f00bb33c5d0d95a79b441c30a6b1c989"
+  integrity sha512-jB4I4/HppiHiSFMqQvMC2Px5Zm8CExA7Bw7xW+o60xh4v0LrNTfKV7LMCGuJNRuUuTTiRcJvF1rbq5mINgQ1UQ==
+  dependencies:
+    "@types/koa" "*"
+    path-to-regexp "^1.7.0"
 
 "@types/koa@*", "@types/koa@2.0.48", "@types/koa@^2.0.46":
   version "2.0.48"
@@ -1000,6 +1041,23 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+awilix-koa@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/awilix-koa/-/awilix-koa-3.1.0.tgz#30db0ad37c09399ff61c3f9c4a6966318fd9099c"
+  integrity sha512-Fa1QQu/5WhCVkGsHZtPdDltxAKAp4Qx0g8VOWcmuopPWr+2HoLDTGSCvUsfqM78X4VK1jLrtERrOX+7LSr+mfQ==
+  dependencies:
+    awilix-router-core "^1.5.0"
+    koa-compose "^4.1.0"
+    koa-router "^7.4.0"
+
+awilix-router-core@^1.5.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/awilix-router-core/-/awilix-router-core-1.6.1.tgz#6d51e1e832bf1284901be6e5554129fbd715f2cf"
+  integrity sha512-Zs2YUSkV8v1PJ6dEp7td/OjQ81gjwsk/lBHMFCwZDpe17efJaz4WNsB97Y/X/FOQ7vQ3+c87+Nvh1HCmHxrhPQ==
+  dependencies:
+    glob "^7.1.3"
+    tslib "^1.9.3"
+
 awilix@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/awilix/-/awilix-4.2.2.tgz#8d5ac4aeedd3ac94dd6cff6ff9cc4b45f0c8d0e3"
@@ -1443,6 +1501,13 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+debug@*, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1454,13 +1519,6 @@ debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -3255,6 +3313,15 @@ koa-is-json@^1.0.0:
   resolved "https://registry.yarnpkg.com/koa-is-json/-/koa-is-json-1.0.0.tgz#273c07edcdcb8df6a2c1ab7d59ee76491451ec14"
   integrity sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ=
 
+koa-route@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/koa-route/-/koa-route-3.2.0.tgz#76298b99a6bcfa9e38cab6fe5c79a8733e758bce"
+  integrity sha1-dimLmaa8+p44yrb+XHmocz51i84=
+  dependencies:
+    debug "*"
+    methods "~1.1.0"
+    path-to-regexp "^1.2.0"
+
 koa-router@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/koa-router/-/koa-router-7.4.0.tgz#aee1f7adc02d5cb31d7d67465c9eacc825e8c5e0"
@@ -3462,7 +3529,7 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-methods@^1.0.1:
+methods@^1.0.1, methods@~1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -3996,7 +4063,7 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-path-to-regexp@^1.1.1:
+path-to-regexp@^1.1.1, path-to-regexp@^1.2.0, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=


### PR DESCRIPTION
- Users can now login using their Google accounts
- If they already exist then they just get back an access token and a refresh token
- If they do not exist then they are created on the fly

-> I think there is a security issue with the current implementation : any app can use our `/authorize/google` endpoint to login. Im not sure this is problematic, but in order to fix it we need to move the authorization code fetching to the front end.