### PR TITLE
Auth: reject invalid requests with 401 & refresh token route

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,4 @@ OPENCAGEDATA_API_KEY=your key here
 OAUTH2_GOOGLE_API_KEY=your key here
 OAUTH2_GOOGLE_API_SECRET=your secret here
 OAUTH2_GOOGLE_REDIRECT_URI=redirect uri
+CORS_ALLOWED_ORIGIN=http://localhost:3001

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dotenv": "7.0.0",
     "graphql": "14.2.1",
     "koa": "2.7.0",
+    "koa-bodyparser": "^4.2.1",
     "koa-route": "^3.2.0",
     "lodash.merge": "4.6.1",
     "node-uuid": "1.4.8"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "dev": "yarn run compile:watch & yarn run serve:watch",
     "build": "tsc",
     "test": "jest",
-    "lint": "eslint --ext .ts ."
+    "lint": "eslint --ext .ts . --fix"
   },
   "dependencies": {
     "@hapi/joi": "^15.0.2",
+    "@koa/cors": "^3.0.0",
     "apollo-server-koa": "2.4.8",
     "awilix": "4.2.2",
     "awilix-koa": "^3.1.0",

--- a/src/infrastructure/server/errors/authenticationError.test.ts
+++ b/src/infrastructure/server/errors/authenticationError.test.ts
@@ -1,0 +1,23 @@
+import { setAuthenticationError } from './authenticationError'
+
+it('should set the HTTP status code to 401', () => {
+  // Given
+  const ctx: any = {}
+
+  // When
+  setAuthenticationError(ctx)
+
+  // Then
+  expect(ctx.status).toEqual(401)
+})
+
+it('should set the response with a message', () => {
+  // Given
+  const ctx: any = {}
+
+  // When
+  setAuthenticationError(ctx)
+
+  // Then
+  expect(ctx.body).toHaveProperty('message')
+})

--- a/src/infrastructure/server/errors/authenticationError.ts
+++ b/src/infrastructure/server/errors/authenticationError.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import Koa from 'koa'
 
 export function setAuthenticationError(ctx: Koa.Context): void {

--- a/src/infrastructure/server/errors/authenticationError.ts
+++ b/src/infrastructure/server/errors/authenticationError.ts
@@ -1,0 +1,8 @@
+import Koa from 'koa'
+
+export function setAuthenticationError(ctx: Koa.Context): void {
+  ctx.status = 401
+  ctx.body = {
+    message: 'Could not authenticate request.',
+  }
+}

--- a/src/infrastructure/server/errors/index.ts
+++ b/src/infrastructure/server/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './authenticationError'

--- a/src/infrastructure/server/index.ts
+++ b/src/infrastructure/server/index.ts
@@ -18,6 +18,7 @@ import { configureGraphql } from './graphql'
 
 dotenv.config()
 
+const corsAllowedOrigin = process.env.CORS_ALLOWED_ORIGIN
 const googleClientId = process.env.OAUTH2_GOOGLE_API_KEY
 const googleClientSecret = process.env.OAUTH2_GOOGLE_API_SECRET
 const googleRedirectUri = process.env.OAUTH2_GOOGLE_REDIRECT_URI
@@ -36,6 +37,10 @@ if (!googleRedirectUri) {
   )
 }
 
+if (!corsAllowedOrigin) {
+  throw new Error('Environment variable "CORS_ALLOWED_ORIGIN" is required')
+}
+
 const port = process.env.PORT
 const container = createContainer()
 
@@ -45,6 +50,7 @@ container.register({
   googleClientSecret: asValue(googleClientSecret),
   googleRedirectUri: asValue(googleRedirectUri),
   openCageDataApiKey: asValue(process.env.OPENCAGEDATA_API_KEY),
+  corsAllowedOrigin: asValue(corsAllowedOrigin),
 
   // Services
   googleAuthService: asClass(GoogleAuthService),

--- a/src/infrastructure/server/middlewares/authorize.ts
+++ b/src/infrastructure/server/middlewares/authorize.ts
@@ -51,7 +51,7 @@ class AuthorizationMiddleware {
 
       return next()
     } catch (err) {
-      setAuthenticationError(ctx)
+      return setAuthenticationError(ctx)
     }
   }
 }

--- a/src/infrastructure/server/middlewares/index.ts
+++ b/src/infrastructure/server/middlewares/index.ts
@@ -1,6 +1,7 @@
 import Koa from 'koa'
 import { AwilixContainer } from 'awilix'
 import { scopePerRequest } from 'awilix-koa'
+import bodyParser from 'koa-bodyparser'
 import cors from '@koa/cors'
 
 import { authorizationMiddleware } from './authorize'
@@ -15,6 +16,7 @@ export const configureMiddlewares = (
         origin: container.resolve<string>('corsAllowedOrigin'),
       })
     )
+    .use(bodyParser())
     .use(scopePerRequest(container))
     .use(authorizationMiddleware)
 

--- a/src/infrastructure/server/middlewares/index.ts
+++ b/src/infrastructure/server/middlewares/index.ts
@@ -1,6 +1,7 @@
 import Koa from 'koa'
 import { AwilixContainer } from 'awilix'
 import { scopePerRequest } from 'awilix-koa'
+import cors from '@koa/cors'
 
 import { authorizationMiddleware } from './authorize'
 
@@ -8,7 +9,14 @@ export const configureMiddlewares = (
   app: Koa,
   container: AwilixContainer
 ): Koa => {
-  app.use(scopePerRequest(container)).use(authorizationMiddleware)
+  app
+    .use(
+      cors({
+        origin: container.resolve<string>('corsAllowedOrigin'),
+      })
+    )
+    .use(scopePerRequest(container))
+    .use(authorizationMiddleware)
 
   return app
 }

--- a/src/infrastructure/server/routes/index.ts
+++ b/src/infrastructure/server/routes/index.ts
@@ -1,8 +1,10 @@
 import Koa from 'koa'
 
+import * as refresh from './refresh'
 import * as oauth2 from './oauth2'
 
 export const configureRoutes = (app: Koa): Koa => {
+  refresh.configureRefresh(app)
   oauth2.configureGoogleRoutes(app)
 
   return app

--- a/src/infrastructure/server/routes/oauth2/google.ts
+++ b/src/infrastructure/server/routes/oauth2/google.ts
@@ -86,5 +86,5 @@ const handler = makeInvoker(GoogleOauth2Api)
 
 export const configureGoogleRoutes = (app: Koa): Koa =>
   app
-    .use(router.get('/authorize/google', handler('redirectToLogin'))) // TODO: remove /google
+    .use(router.get('/authorize/google', handler('redirectToLogin')))
     .use(router.get('/oauth2/google', handler('handleOauth2Callback')))

--- a/src/infrastructure/server/routes/oauth2/google.ts
+++ b/src/infrastructure/server/routes/oauth2/google.ts
@@ -84,10 +84,7 @@ class GoogleOauth2Api {
 
 const handler = makeInvoker(GoogleOauth2Api)
 
-export const configureGoogleRoutes = (app: Koa): Koa => {
+export const configureGoogleRoutes = (app: Koa): Koa =>
   app
-    .use(router.get('/authorize/google', handler('redirectToLogin')))
+    .use(router.get('/authorize/google', handler('redirectToLogin'))) // TODO: remove /google
     .use(router.get('/oauth2/google', handler('handleOauth2Callback')))
-
-  return app
-}

--- a/src/infrastructure/server/routes/refresh/google.ts
+++ b/src/infrastructure/server/routes/refresh/google.ts
@@ -1,0 +1,46 @@
+import Koa from 'koa'
+import Joi from '@hapi/joi'
+
+import { GoogleAuthService } from '../../../../infrastructure/services/GoogleAuthService'
+import { validateSchemaOrThrow } from '../../util'
+import { makeInvoker } from 'awilix-koa'
+
+interface RefreshBody {
+  refreshToken: string
+}
+
+interface Dependencies {
+  googleAuthService: GoogleAuthService
+}
+
+class GoogleRefreshApi {
+  private googleAuthService: GoogleAuthService
+
+  public constructor({ googleAuthService }: Dependencies) {
+    this.googleAuthService = googleAuthService
+  }
+
+  public refreshAccessToken: Koa.Middleware = async ctx => {
+    const body: RefreshBody = ctx.request.body
+    validateSchemaOrThrow(
+      Joi.object()
+        .keys({
+          refreshToken: Joi.string().required(),
+        })
+        .required(),
+      body
+    )
+
+    const accessToken = await this.googleAuthService.refreshAccessToken(
+      body.refreshToken
+    )
+
+    ctx.body = {
+      accessToken,
+    }
+  }
+}
+
+const invoker = makeInvoker(GoogleRefreshApi)
+
+export const refreshHandler = invoker('refreshAccessToken')

--- a/src/infrastructure/server/routes/refresh/google.ts
+++ b/src/infrastructure/server/routes/refresh/google.ts
@@ -35,6 +35,7 @@ class GoogleRefreshApi {
       body.refreshToken
     )
 
+    // eslint-disable-next-line no-param-reassign
     ctx.body = {
       accessToken,
     }

--- a/src/infrastructure/server/routes/refresh/index.ts
+++ b/src/infrastructure/server/routes/refresh/index.ts
@@ -1,0 +1,7 @@
+import Koa from 'koa'
+import router from 'koa-route'
+
+import { refreshHandler } from './google'
+
+export const configureRefresh = (app: Koa): Koa =>
+  app.use(router.post('/refresh', refreshHandler))

--- a/src/infrastructure/services/GoogleAuthService.ts
+++ b/src/infrastructure/services/GoogleAuthService.ts
@@ -12,6 +12,10 @@ interface GoogleTokenResponse {
   refresh_token: string
 }
 
+interface GoogleRefreshTokenResponse {
+  access_token: string
+}
+
 interface GoogleUserResponse {
   sub: string
   email: string
@@ -81,5 +85,16 @@ export class GoogleAuthService {
         },
       })
       .then(response => response.data)
+  }
+
+  public refreshAccessToken(refreshToken: string): Promise<string> {
+    return axios
+      .post<GoogleRefreshTokenResponse>(`${API_V4_ENDPOINT}/token`, {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      })
+      .then(response => response.data.access_token)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,6 +328,13 @@
   dependencies:
     vary "^1.1.2"
 
+"@koa/cors@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-3.0.0.tgz#df021b4df2dadf1e2b04d7c8ddf93ba2d42519cb"
+  integrity sha512-hDp+cXj6vTYSwHRJfiSpnf5dTMv3FmqNKh1or9BPJk4SHOviHnK9GoL9dT0ypt/E+hlkRkZ9edHylcosW3Ghrw==
+  dependencies:
+    vary "^1.1.2"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,6 +1230,11 @@ bytes@2.4.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
   integrity sha1-fZcZb51br39pNeJZhVSe3SpsIzk=
 
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1353,6 +1358,16 @@ co-body@^4.2.0:
     raw-body "~2.1.2"
     type-is "~1.6.6"
 
+co-body@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/co-body/-/co-body-6.0.0.tgz#965b9337d7f5655480787471f4237664820827e3"
+  integrity sha512-9ZIcixguuuKIptnY8yemEOuhb71L/lLf+Rl5JfJEUiDNJk0e02MBt7BPxR2GEh5mw8dPthQYR4jPI/BnS1MQgw==
+  dependencies:
+    inflation "^2.0.0"
+    qs "^6.5.2"
+    raw-body "^2.3.3"
+    type-is "^1.6.16"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1451,6 +1466,11 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+copy-to@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/copy-to/-/copy-to-2.0.1.tgz#2680fbb8068a48d08656b6098092bdafc906f4a5"
+  integrity sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU=
 
 core-js@3.0.0-beta.13:
   version "3.0.0-beta.13"
@@ -2399,7 +2419,7 @@ http-assert@^1.3.0:
     deep-equal "~1.0.1"
     http-errors "~1.7.2"
 
-http-errors@^1.3.1, http-errors@^1.6.3, http-errors@^1.7.2, http-errors@~1.7.2:
+http-errors@1.7.2, http-errors@^1.3.1, http-errors@^1.6.3, http-errors@^1.7.2, http-errors@~1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
   integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
@@ -2464,7 +2484,7 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-inflation@~2.0.0:
+inflation@^2.0.0, inflation@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/inflation/-/inflation-2.0.0.tgz#8b417e47c28f925a45133d914ca1fd389107f30f"
   integrity sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8=
@@ -3287,6 +3307,14 @@ koa-bodyparser@^3.0.0:
   integrity sha1-uRbeF+IDn+gmUEgZc9fClPELVxk=
   dependencies:
     co-body "^4.2.0"
+
+koa-bodyparser@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/koa-bodyparser/-/koa-bodyparser-4.2.1.tgz#4d7dacb5e6db1106649b595d9e5ccb158b6f3b29"
+  integrity sha512-UIjPAlMZfNYDDe+4zBaOAUKYqkwAGcIU6r2ARf1UOXPAlfennQys5IiShaVeNf7KkVBlf88f2LeLvBFvKylttw==
+  dependencies:
+    co-body "^6.0.0"
+    copy-to "^2.0.1"
 
 koa-compose@^3.0.0:
   version "3.2.1"
@@ -4222,6 +4250,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+qs@^6.5.2:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 qs@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-4.0.0.tgz#c31d9b74ec27df75e543a86c78728ed8d4623607"
@@ -4231,6 +4264,16 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+raw-body@^2.3.3:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 raw-body@~2.1.2:
   version "2.1.7"


### PR DESCRIPTION
Before this Pull Request, when the access token was invalid or expired, the server rejected the requests with a status code set to 500.

With the Pull Request, we set the status code to 401, allowing the front-end to implement a mechanism for refreshing the access tokens when 401 occur.

+ CORS has been setup